### PR TITLE
Work around UnicodeEncodeError when attaching unicode HTML content

### DIFF
--- a/mail_factory/mails.py
+++ b/mail_factory/mails.py
@@ -118,6 +118,8 @@ class BaseMail(object):
                                          "SUPPORT_EMAIL",
                                          settings.DEFAULT_FROM_EMAIL)})
         if html_content:
+            if isinstance(html_content, unicode):
+                html_content = html_content.encode('utf-8')
             msg.attach_alternative(html_content, 'text/html')
 
         return msg


### PR DESCRIPTION
See this ticket: https://code.djangoproject.com/ticket/20230

Only occurs on Python < 2.6.6. Since the ticket is marked as wontfix
in Django, it makes sense to fix it here.